### PR TITLE
fix bug that no deployment id was found

### DIFF
--- a/single-tenant/code/srv/utils/langchain/BTPAzureOpenAIChatLLM.ts
+++ b/single-tenant/code/srv/utils/langchain/BTPAzureOpenAIChatLLM.ts
@@ -65,8 +65,10 @@ export default class BTPAzureBaseChatLLM extends SimpleChatModel<ChatOpenAICallO
             this.config?.deploymentId || (await aiCore.getDeploymentId(resourceGroupId, aiCore.Tasks.CHAT));
         if (deploymentId) {
             const aiCoreService = await cds.connect.to(this.config?.destination || aiCore.AI_CORE_DESTINATION);
-            const payload: any = {
-                messages: [
+
+            let messagesIn;
+            if (messages.length === 2) {
+                messagesIn = [
                     {
                         role: "system",
                         content: messages[0].content
@@ -75,7 +77,19 @@ export default class BTPAzureBaseChatLLM extends SimpleChatModel<ChatOpenAICallO
                         role: "user",
                         content: messages[1].content
                     }
-                ],
+                ];
+            } else if (messages.length === 1) {
+                // on retry (OutputFixingParser) there is only one message
+                messagesIn = [
+                    {
+                        role: "user",
+                        content: messages[0].content
+                    }
+                ];
+            }
+
+            const payload: any = {
+                messages: messagesIn,
                 ...this.params
             };
             const headers = { "Content-Type": "application/json", "AI-Resource-Group": resourceGroupId };

--- a/single-tenant/code/tsconfig.json
+++ b/single-tenant/code/tsconfig.json
@@ -17,8 +17,5 @@
     "esModuleInterop": true,
     "resolveJsonModule": true
   },
-  "ts-node": {
-    "swc": true
-  },
   "include": ["./srv/**/*"]
 }


### PR DESCRIPTION
A colleague in Rumania encountered an error, when she tried to add a new mail (/addMails endpoint). This is the fix (for the single tenant variant only for now).

- **fix: no deployment id found**
- **fix: on retry (OutputFixingParser) there is one message, not two**
- **swc for ts-node not needed**
